### PR TITLE
🔧 Fix candy start command path for Render

### DIFF
--- a/candy/DEPLOYMENT.md
+++ b/candy/DEPLOYMENT.md
@@ -24,8 +24,15 @@ npm install && npm run build
 
 #### Start Command
 ```bash
+cd candy && node .output/server/index.mjs
+```
+
+**Important:** If you set `Root Directory: candy` in Render UI, use:
+```bash
 node .output/server/index.mjs
 ```
+
+But if building from repo root, the start command must include `cd candy &&`.
 
 #### Environment Variables
 
@@ -73,10 +80,10 @@ Ensure all required environment variables are set in Render dashboard under "Env
 
 2. **Configure Service**
    - Name: `kwami-candy-machine`
-   - Root Directory: `candy`
+   - Root Directory: `candy` (or leave empty and use full path in start command)
    - Environment: `Node`
-   - Build Command: `npm install && npm run build`
-   - Start Command: `node .output/server/index.mjs`
+   - Build Command: `npm install && npm run build` (or `npm run build:candy` if root is empty)
+   - Start Command: `cd candy && node .output/server/index.mjs` (or just `node .output/server/index.mjs` if root is `candy`)
 
 3. **Set Environment Variables**
    - Add all required environment variables listed above

--- a/candy/render.yaml
+++ b/candy/render.yaml
@@ -5,7 +5,7 @@ services:
     plan: free
     rootDir: candy
     buildCommand: npm install && npm run build
-    startCommand: node .output/server/index.mjs
+    startCommand: cd candy && node .output/server/index.mjs
     envVars:
       - key: NODE_VERSION
         value: 25.2.1


### PR DESCRIPTION
## Problem

After successful build, Render fails to start the app:
```
Error: Cannot find module '/opt/render/project/src/.output/server/index.mjs'
```

The build creates output at `candy/.output/server/index.mjs` but the start command runs from repo root and can't find it.

## Root Cause

Render's `rootDir` setting applies to the build context but NOT to the start command execution directory. The start command always runs from `/opt/render/project/src` (repo root).

## Solution

Updated start command to explicitly navigate to candy directory:

### Before:
```bash
startCommand: node .output/server/index.mjs
```

### After:
```bash
startCommand: cd candy && node .output/server/index.mjs
```

## Changes

- ✅ Updated `candy/render.yaml` with correct start command
- ✅ Updated `candy/DEPLOYMENT.md` with path clarifications
- ✅ Added documentation about rootDir behavior

## Testing

With this fix, the start command will:
1. Navigate to candy directory
2. Find the built output at `.output/server/index.mjs`
3. Start the Nuxt server successfully

## Render Configuration

Update your Render start command to:
```bash
cd candy && node .output/server/index.mjs
```