### PR TITLE
🔧 Fix web deployment: kwami dependency version

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -25,7 +25,7 @@
     "i18next": "^25.6.2",
     "i18next-browser-languagedetector": "^8.2.0",
     "js-yaml": "^4.1.1",
-    "kwami": "*",
+    "kwami": "^1.5.7",
     "simplex-noise": "^4.0.1",
     "three": "^0.181.1"
   },


### PR DESCRIPTION
## 🎯 Fix for Render Deployment Error

Fixes the remaining deployment error after PR #28 was merged.

## ❌ Error on Render:
```
npm error Invalid Version:
```

## ✅ Fix:

Changed kwami dependency in `web/package.json`:

```diff
- "kwami": "*",
+ "kwami": "^1.5.7",
```

## Why This Happened:

- Wildcard `*` versions work in monorepo workspaces locally
- But npm on Render doesn't accept wildcard versions
- Need explicit version or range (^1.5.7)

## 🧪 Testing:

Build should now succeed on Render:
```bash
npm install  # No more 'Invalid Version' error
npm run build:web  # Succeeds
```

## 📦 Changes:

**1 file changed, 1 line**
- `web/package.json` - kwami dependency version

## 🚀 Deployment:

After merge:
- ✅ Web landing page builds successfully on Render
- ✅ All workspace dependencies resolve correctly

---

**Builds on top of:** PR #28 (already merged)  
**Fixes:** npm Invalid Version error  
**Ready to merge!** ✅