### PR TITLE
ci: bump GitHub Actions and target Dependabot at dev

### DIFF
--- a/.github/actions/setup-workspace/action.yml
+++ b/.github/actions/setup-workspace/action.yml
@@ -12,7 +12,7 @@ runs:
     - uses: pnpm/action-setup@v4
       # The pnpm version comes from package.json "packageManager" — do not pin it twice.
 
-    - uses: actions/setup-node@v6
+    - uses: actions/setup-node@v7
       with:
         node-version-file: .nvmrc
         cache: pnpm

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,8 @@ updates:
   # supply-chain risk, not a convenience.
   - package-ecosystem: github-actions
     directory: /
+    # Same promote path as npm: land on `dev`, never open straight into `main`.
+    target-branch: dev
     schedule:
       interval: weekly
       day: monday

--- a/.github/workflows/branch-promotion.yml
+++ b/.github/workflows/branch-promotion.yml
@@ -34,13 +34,13 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           # The base branch's copy of the rules, not the PR's — a PR must not be able to edit
           # the gate that judges it.
           ref: ${{ github.event.pull_request.base.sha }}
 
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@v7
         with:
           node-version-file: .nvmrc
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
       - uses: ./.github/actions/setup-workspace
@@ -55,7 +55,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - uses: ./.github/actions/setup-workspace
 
       - name: Lint
@@ -80,7 +80,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - uses: ./.github/actions/setup-workspace
 
       # Coverage runs the same tests as `pnpm test:unit` plus the ratchet in vitest.config.ts
@@ -91,7 +91,7 @@ jobs:
       - name: CI scripts (node:test)
         run: pnpm test:ci-scripts
 
-      - uses: actions/upload-artifact@v5
+      - uses: actions/upload-artifact@v7
         if: always()
         with:
           name: coverage
@@ -104,7 +104,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - uses: ./.github/actions/setup-workspace
 
       # Boots a real node:http server and drives the api-client over a real socket.
@@ -117,7 +117,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - uses: ./.github/actions/setup-workspace
 
       - name: Build the library
@@ -135,7 +135,7 @@ jobs:
           echo '' >> "$GITHUB_STEP_SUMMARY"
           echo "\`dist\` is $(du -sh dist | cut -f1) across $(find dist -type f | wc -l) files." >> "$GITHUB_STEP_SUMMARY"
 
-      - uses: actions/upload-artifact@v5
+      - uses: actions/upload-artifact@v7
         with:
           name: dist
           path: dist/
@@ -147,12 +147,12 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - uses: ./.github/actions/setup-workspace
 
       # Reuse the artifact the build job produced: the e2e layer's whole point is to test the
       # bundle that would actually be published, not a second build of it.
-      - uses: actions/download-artifact@v6
+      - uses: actions/download-artifact@v8
         with:
           name: dist
           path: dist/
@@ -165,7 +165,7 @@ jobs:
       - name: E2E tests
         run: pnpm test:e2e
 
-      - uses: actions/upload-artifact@v5
+      - uses: actions/upload-artifact@v7
         if: failure()
         with:
           name: playwright-report

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,7 +52,7 @@ jobs:
       # Empty on a manual run — there is no "the commit ci tested", so the drift guard stands down.
       TESTED_SHA: ${{ github.event.workflow_run.head_sha }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           # The branch, not the tested SHA: semantic-release commits and pushes onto it. The
           # guard below refuses to release if the two have drifted apart.


### PR DESCRIPTION
## Summary

- Replaces [#63](https://github.com/kwami-labs/kwami/pull/63): Dependabot opened the actions group bump against `main`, which `branch-promotion` correctly rejects
- Bumps `actions/checkout` → v7, `actions/setup-node` → v7, `actions/upload-artifact` → v7, `actions/download-artifact` → v8 (workflows + setup-workspace)
- Sets `target-branch: dev` on the `github-actions` Dependabot ecosystem so future bumps follow `feature/* → dev → stg → main`

## Scope

- [x] `src/avatar` (renderers, scene, audio)
- [x] `src/agent` (voice pipeline, LiveKit adapter)
- [x] `src/soul` / `src/memory` / `src/tools` / `src/skills`
- [x] Public API — `src/index.ts` or `src/types`
- [x] Tooling / CI / docs (releases nothing on its own)

## Test plan

| Check       | Command                 | Result |
| ----------- | ----------------------- | ------ |
| Lint        | `pnpm lint`             |        |
| Types       | `pnpm typecheck`        |        |
| Unit        | `pnpm test:unit`        |        |
| Integration | `pnpm test:integration` |        |
| E2E         | `pnpm test:e2e`         |        |
| Build       | `pnpm build`            |        |

## Public API

- [x] No change to the published surface

## Checklist

- [x] Targets `dev` (the promote path is `feature/* → dev → stg → main`)
- [x] Conventional Commit title
- [x] No secrets, `.env` values, or build output committed
- [x] `CHANGELOG.md` and the `version` field untouched — semantic-release owns them

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Workflow and Dependabot configuration only; no application code, auth, or publish logic changes beyond action version pins.
> 
> **Overview**
> Updates pinned GitHub Actions across CI, release, branch promotion, and the composite **setup-workspace** action: **`actions/checkout`** and **`actions/setup-node`** move to **v7**, **`actions/upload-artifact`** to **v7**, and **`actions/download-artifact`** (e2e dist reuse) to **v8**.
> 
> Adds **`target-branch: dev`** to Dependabot’s **`github-actions`** ecosystem so automated action bumps open on **`dev`** (matching npm and the **`feature/* → dev → stg → main`** promote path) instead of **`main`**, where **`branch-promotion`** would reject them.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 775075ce907170ed7f283bc2c47cfedccf8a7a8c. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->