### PR TITLE
fix(build): enable semantic-release and attribute package externals fix

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -59,6 +59,7 @@ jobs:
           ref: ${{ github.event.workflow_run.head_branch || github.ref_name }}
           # Full history and tags — semantic-release derives everything from them.
           fetch-depth: 0
+          fetch-tags: true
           # We point origin at a token URL below so the back-merge pushes work too.
           persist-credentials: false
 
@@ -70,6 +71,22 @@ jobs:
           git config user.name 'github-actions[bot]'
           git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
           git remote set-url origin "https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
+
+      # semantic-release runs `git tag --merged <branch>` for every channel in .releaserc.cjs.
+      # checkout only creates a local ref for the branch being released, so `main` is missing
+      # when releasing from stg/dev (and vice versa) — materialise the rest from origin/*.
+      - name: Materialise release channel branches
+        run: |
+          set -euo pipefail
+          for b in main stg dev; do
+            if git show-ref --verify --quiet "refs/heads/${b}"; then
+              echo "local ${b} already exists"
+            else
+              git branch "${b}" "origin/${b}"
+              echo "created local ${b} from origin/${b}"
+            fi
+          done
+          git branch -vv | grep -E 'main|stg|dev'
 
       # A push that landed while CI was running has its own CI run behind it; let that one
       # release rather than shipping a commit these gates never saw.


### PR DESCRIPTION
## Summary

- Fixes `release.yml`: materialise local `main`/`stg`/`dev` refs and fetch tags so semantic-release stops failing with `malformed object name main`
- Empty `fix(build):` commit so the OrbitControls/`three/examples` packaging fix (buried in a `ci:` squash) can cut a patch release on `main`

## Scope

- [x] Tooling / CI / docs

## Checklist

- [x] Targets `dev`
- [x] Conventional Commit title

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only release pipeline changes; no runtime, auth, or publish logic beyond ensuring git refs and tags exist before semantic-release runs.
> 
> **Overview**
> Fixes the **release** workflow so semantic-release can run when releasing from `stg` or `dev`, where checkout previously left only the active branch as a local ref and `git tag --merged <channel>` failed (e.g. `malformed object name main`).
> 
> **Checkout** now sets **`fetch-tags: true`** so tag history is available with `fetch-depth: 0`. A new step **materialises local `main`, `stg`, and `dev`** from `origin/*` when they are missing, matching what `.releaserc.cjs` expects for multi-channel tagging.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 602aca901d9978e6f81b3bfc15d07a0accb7fd58. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->