### PR TITLE
fix(build): promote semantic-release fix to stg

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -59,6 +59,7 @@ jobs:
           ref: ${{ github.event.workflow_run.head_branch || github.ref_name }}
           # Full history and tags — semantic-release derives everything from them.
           fetch-depth: 0
+          fetch-tags: true
           # We point origin at a token URL below so the back-merge pushes work too.
           persist-credentials: false
 
@@ -70,6 +71,22 @@ jobs:
           git config user.name 'github-actions[bot]'
           git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
           git remote set-url origin "https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
+
+      # semantic-release runs `git tag --merged <branch>` for every channel in .releaserc.cjs.
+      # checkout only creates a local ref for the branch being released, so `main` is missing
+      # when releasing from stg/dev (and vice versa) — materialise the rest from origin/*.
+      - name: Materialise release channel branches
+        run: |
+          set -euo pipefail
+          for b in main stg dev; do
+            if git show-ref --verify --quiet "refs/heads/${b}"; then
+              echo "local ${b} already exists"
+            else
+              git branch "${b}" "origin/${b}"
+              echo "created local ${b} from origin/${b}"
+            fi
+          done
+          git branch -vv | grep -E 'main|stg|dev'
 
       # A push that landed while CI was running has its own CI run behind it; let that one
       # release rather than shipping a commit these gates never saw.


### PR DESCRIPTION
## Summary

- Promote #70 to `stg`: release.yml channel-branch fix + releasable packaging externals attribution

## Checklist

- [x] Targets `stg`
- [x] Head is this repo's current tip of `dev`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only release workflow changes with no application or security impact.
> 
> **Overview**
> Fixes **release** workflow failures when cutting **stg** or **dev** builds: semantic-release needs **`git tag --merged`** on every channel branch (`main`, `stg`, `dev`), but checkout only checked out the branch being released.
> 
> The workflow now enables **`fetch-tags: true`** on checkout and adds a step that creates any missing local **`main` / `stg` / `dev`** refs from **`origin/*`** before release runs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5715e6cd94c0f656370569a7f5eb796cae12b383. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->