### PR TITLE
fix(build): promote semantic-release fix to main

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -59,6 +59,7 @@ jobs:
           ref: ${{ github.event.workflow_run.head_branch || github.ref_name }}
           # Full history and tags — semantic-release derives everything from them.
           fetch-depth: 0
+          fetch-tags: true
           # We point origin at a token URL below so the back-merge pushes work too.
           persist-credentials: false
 
@@ -70,6 +71,22 @@ jobs:
           git config user.name 'github-actions[bot]'
           git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
           git remote set-url origin "https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
+
+      # semantic-release runs `git tag --merged <branch>` for every channel in .releaserc.cjs.
+      # checkout only creates a local ref for the branch being released, so `main` is missing
+      # when releasing from stg/dev (and vice versa) — materialise the rest from origin/*.
+      - name: Materialise release channel branches
+        run: |
+          set -euo pipefail
+          for b in main stg dev; do
+            if git show-ref --verify --quiet "refs/heads/${b}"; then
+              echo "local ${b} already exists"
+            else
+              git branch "${b}" "origin/${b}"
+              echo "created local ${b} from origin/${b}"
+            fi
+          done
+          git branch -vv | grep -E 'main|stg|dev'
 
       # A push that landed while CI was running has its own CI run behind it; let that one
       # release rather than shipping a commit these gates never saw.


### PR DESCRIPTION
## Summary

- Promote #70/#71 to `main` so a patch release can ship (release.yml fix + packaging externals attribution)

## Checklist

- [x] Targets `main`
- [x] Head is this repo's current tip of `stg`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the semantic-release workflow; incorrect git refs could affect versioning or tagging, but the change is narrowly scoped to local branch setup.
> 
> **Overview**
> **Fixes semantic-release on `stg`/`dev` when `git tag --merged` needs refs for every channel in `.releaserc.cjs`.**
> 
> The release workflow now enables **`fetch-tags: true`** on checkout so tags are available locally, and adds a **Materialise release channel branches** step that creates local `main`, `stg`, and `dev` from `origin/*` when checkout only checked out the branch being released.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 69d566cbdd55389c3e502c27b29cc661dad5606b. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->